### PR TITLE
Closes upstream-owner/VeriFund#4

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -16,4 +16,185 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans), system-ui, sans-serif;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+/* Global dark mode — toggled via .dark on <html> */
+.dark {
+  --background: #111827;
+  --foreground: #f9fafb;
+}
+
+.dark .text-gray-900 {
+  color: #f9fafb;
+}
+
+.dark .text-gray-500 {
+  color: #9ca3af;
+}
+
+.dark .text-gray-400 {
+  color: #9ca3af;
+}
+
+.dark .text-gray-600 {
+  color: #d1d5db;
+}
+
+.dark .text-gray-700 {
+  color: #e5e7eb;
+}
+
+.dark .bg-white,
+.dark .bg-white\/80 {
+  background-color: #1f2937;
+}
+
+/* Preserve explicit button styling inside colored sections (CTA) */
+.dark .bg-gradient-to-br button.bg-white {
+  background-color: white;
+  color: inherit;
+}
+
+.dark .bg-gradient-to-br button.text-white {
+  color: white;
+}
+
+.dark .bg-gradient-to-br button.text-emerald-700 {
+  color: #047857;
+}
+
+.dark .bg-gradient-to-br button.border-emerald-300 {
+  border-color: #6ee7b7;
+}
+
+.dark .bg-gradient-to-br button.hover\:bg-emerald-50:hover {
+  background-color: #ecfdf5;
+}
+
+.dark .bg-gradient-to-br button.hover\:bg-emerald-500:hover {
+  background-color: #10b981;
+}
+
+.dark .border-gray-200 {
+  border-color: #374151;
+}
+
+.dark .border-gray-100 {
+  border-color: #374151;
+}
+
+.dark .divide-gray-100 > :not(:last-child) {
+  border-color: #374151;
+}
+
+.dark .bg-gray-200 {
+  background-color: #374151;
+}
+
+.dark .bg-gray-50 {
+  background-color: #374151;
+}
+
+.dark .hover\:bg-gray-50:hover {
+  background-color: #374151;
+}
+
+.dark .bg-red-50 {
+  background-color: #7f1d1d;
+}
+
+.dark .text-red-700 {
+  color: #fca5a5;
+}
+
+/* Dark mode form inputs — lighter than container so they stand out */
+.dark input,
+.dark textarea,
+.dark select {
+  background-color: #374151;
+  border-color: #4b5563;
+  color: #f9fafb;
+}
+
+.dark input::placeholder,
+.dark textarea::placeholder {
+  color: #9ca3af;
+}
+
+.dark select option {
+  background-color: #374151;
+  color: #f9fafb;
+}
+
+/* Dark mode gradients and section backgrounds */
+.dark .bg-gradient-to-br.from-emerald-50,
+.dark .from-emerald-50 {
+  --tw-gradient-from: #064e3b;
+  --tw-gradient-to: #111827;
+}
+
+.dark .via-white {
+  --tw-gradient-via: #1f2937;
+}
+
+.dark .to-teal-50 {
+  --tw-gradient-to: #111827;
+}
+
+.dark .bg-emerald-100 {
+  background-color: #064e3b;
+}
+
+.dark .text-emerald-700 {
+  color: #6ee7b7;
+}
+
+.dark .bg-emerald-50 {
+  background-color: #064e3b;
+}
+
+.dark .bg-rose-50 {
+  background-color: #4c0519;
+}
+
+.dark .bg-purple-50 {
+  background-color: #3b0764;
+}
+
+.dark .bg-blue-50 {
+  background-color: #1e3a5f;
+}
+
+.dark .bg-blue-100 {
+  background-color: #1e3a5f;
+}
+
+.dark .text-blue-700 {
+  color: #93c5fd;
+}
+
+.dark .bg-amber-50 {
+  background-color: #451a03;
+}
+
+.dark .bg-teal-50 {
+  background-color: #042f2e;
+}
+
+.dark .shadow-sm {
+  --tw-shadow-color: rgba(0, 0, 0, 0.3);
+}
+
+.dark .hover\:shadow-lg:hover {
+  --tw-shadow-color: rgba(0, 0, 0, 0.4);
+}
+
+/* Dark mode decorative blobs */
+.dark .bg-emerald-200 {
+  background-color: #065f46;
+}
+
+.dark .bg-teal-200 {
+  background-color: #0d9488;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -239,7 +239,7 @@ export default function LandingPage() {
               </Button>
             </Link>
             <Link href="/cases">
-              <Button size="lg" variant="outline" className="border-emerald-300 text-white hover:bg-emerald-500">
+              <Button size="lg" variant="outline" className="border-emerald-300 bg-transparent text-white hover:bg-emerald-500">
                 Browse Cases
               </Button>
             </Link>

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { AuthProvider } from "@/lib/auth-context";
+import { ThemeProvider } from "@/lib/theme-context";
 import { Navbar } from "@/components/navbar";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <AuthProvider>
-      <Navbar />
-      <main className="flex-1">{children}</main>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <Navbar />
+        <main className="flex-1">{children}</main>
+      </AuthProvider>
+    </ThemeProvider>
   );
 }

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { useAuth } from "@/lib/auth-context";
 import { Button } from "@/components/ui/button";
 import { NotificationBell } from "@/components/notification-bell";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Shield, Menu, X, Heart, LayoutDashboard, FolderOpen, LogOut } from "lucide-react";
 
 export function Navbar() {
@@ -19,7 +20,7 @@ export function Navbar() {
   };
 
   return (
-    <nav className="sticky top-0 z-40 border-b border-gray-200 bg-white/80 backdrop-blur-md">
+    <nav className="sticky top-0 z-40 border-b border-gray-200 bg-white/80 backdrop-blur-md dark:bg-gray-900/80 dark:border-gray-700">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
           <Link href="/" className="flex items-center gap-2">
@@ -57,6 +58,7 @@ export function Navbar() {
                     <LogOut className="h-4 w-4" />
                   </Button>
                 </div>
+                <ThemeToggle />
               </>
             ) : (
               <>
@@ -69,16 +71,20 @@ export function Navbar() {
                 <Link href="/register">
                   <Button size="sm">Sign up</Button>
                 </Link>
+                <ThemeToggle />
               </>
             )}
           </div>
 
-          <button
-            className="md:hidden p-2 text-gray-600"
-            onClick={() => setMobileOpen(!mobileOpen)}
-          >
-            {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
-          </button>
+          <div className="flex md:hidden items-center gap-1">
+            <ThemeToggle />
+            <button
+              className="p-2 text-gray-600"
+              onClick={() => setMobileOpen(!mobileOpen)}
+            >
+              {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+            </button>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/theme-toggle.tsx
+++ b/frontend/src/components/theme-toggle.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "@/lib/theme-context";
+
+export function ThemeToggle() {
+  const { dark, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className={`p-2 rounded-lg transition-colors ${
+        dark
+          ? "bg-gray-700 text-yellow-300 hover:bg-gray-600"
+          : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+      }`}
+      aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
+      title={dark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {dark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  );
+}

--- a/frontend/src/lib/theme-context.tsx
+++ b/frontend/src/lib/theme-context.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface ThemeContextType {
+  dark: boolean;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType>({ dark: false, toggleTheme: () => {} });
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    setDark(localStorage.getItem("verifund-theme") === "dark");
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark);
+  }, [dark]);
+
+  const toggleTheme = () => {
+    setDark((prev) => {
+      const next = !prev;
+      localStorage.setItem("verifund-theme", next ? "dark" : "light");
+      return next;
+    });
+  };
+
+  return (
+    <ThemeContext.Provider value={{ dark, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}


### PR DESCRIPTION
Adds dark/light mode toggle to the UI.
- Sun/Moon icon in the navbar (visible on all screen sizes)
- Theme persists via localStorage
- All pages adapt: landing, login, register, dashboard, cases
- Input fields styled for contrast in dark mode
Verified its responsiveness over all pages.

Closes #4

<img width="450" height="400" alt="image" src="https://github.com/user-attachments/assets/9eb3204a-8a0a-43fc-a152-85675aac2dd5" />

